### PR TITLE
富士通研究所　コンピュータテクノロジーズを協賛企業から削除

### DIFF
--- a/ja/collaboration.html
+++ b/ja/collaboration.html
@@ -38,7 +38,7 @@
             トップエスイーの受講者数などの実績は，<a href="admission-info.html">こちら</a>をご覧ください．
         </p>
         <h2>トップエスイーへの協賛</h2>
-        <p>トップエスイーを運営しております国立情報学研究所GRACEセンターの活動に，次の企業様よりご協賛いただいております．(2023年11月現在 67社)
+        <p>トップエスイーを運営しております国立情報学研究所GRACEセンターの活動に，次の企業様よりご協賛いただいております．(2025年1月現在 65社)
             ご協賛いただきますと，所属されている方のトップエスイー受講が容易になります．詳細はお問い合わせください．</p>
         <h2>PBL with UCL</h2>
         <p>英国のUCL (<a href="http://www.ucl.ac.uk/" target="_blank">University College London</a>) の学生とトップエスイー受講生の
@@ -115,8 +115,6 @@
             <li><a href="http://www.formaltech.co.jp/" target="_blank">株式会社フォーマルテック</a></li>
             <li><a href="https://fukushima.canon/ja/" target="_blank">福島キヤノン株式会社</a></li>
             <li><a href="http://jp.fujitsu.com/" target="_blank">富士通株式会社</a></li>
-            <li><a href="http://jp.fujitsu.com/group/labs/" target="_blank">株式会社富士通研究所</a></li>
-            <li><a href="http://jp.fujitsu.com/group/fct/" target="_blank">株式会社富士通コンピュータテクノロジーズ</a></li>
             <li><a href="http://www.voice-research.com/" target="_blank">株式会社ボイスリサーチ</a></li>
             <li><a href="http://www.mamezou-hd.com/" target="_blank">株式会社 豆蔵ホールディングス</a></li>
             <li><a href="http://www.mizuho-ir.co.jp/" target="_blank">みずほリサーチ＆テクノロジーズ株式会社</a></li>


### PR DESCRIPTION
富士通研究所　コンピュータテクノロジーズを協賛企業から削除